### PR TITLE
Add historical rollup windows

### DIFF
--- a/predictor.py
+++ b/predictor.py
@@ -42,7 +42,7 @@ from feature_engineering import _prepare_training_frame, drop_outliers
 # ─────────────────────────────────────────────────────────────────────────────
 # CONFIG
 # ─────────────────────────────────────────────────────────────────────────────
-ROLL_N = 5
+ROLL_WINDOWS = [1, 3, 10]
 DEFAULT_START_TIMES   = list(range(24))     # 0..23 hours
 DEFAULT_DURATIONS_HRS = list(range(2, 13))  # 2..12 hours
 _ARTIFACT_PATH = os.path.join(os.path.dirname(__file__), "predictor_artifacts.joblib")


### PR DESCRIPTION
## Summary
- generate historical features for 1, 3 and 10 day windows
- expose the same rollup configuration in the predictor module

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6885314674388322b1eb2902f2d872df